### PR TITLE
Fixing cookbook broken links

### DIFF
--- a/content/Introduction/cfde.md
+++ b/content/Introduction/cfde.md
@@ -1,4 +1,4 @@
-# Engaging with CFDE:
+# Engaging with CFDE
 
 On January 29, 2020, the NIH Common Fund posted OTA-20-005 Engaging Common Fund Data Coordinating Centers to Establish the Common Fund Data Ecosystem. This announcement invites Engagement Plans from Common Fund Data Coordinating Centers (DCCs) to engage with the Common Fund Data Ecosystem Coordinating Center (CFDE-CC) and with each other to establish the CFDE. The original announcement provided dates for two rounds of Engagement Plan submissions and review.
 
@@ -6,12 +6,10 @@ Based on lessons learned from the first round of Engagement Plan submission and 
 
 For more information, a full overview of the engagement process is available from the [NIH-CFDE project page](https://nih-cfde.org/engagement/).
 
-In addition, a specific chapter details technical aspects and requirements, with the following subsections:
+<!-- In addition, a specific chapter details technical aspects and requirements, with the following subsections:
 
 1. [Implementation Details](https://nih-cfde.org/engagement_page/c2m2-guidelines/#user-content-implementation-details)
 2. [Metadata](https://nih-cfde.org/engagement_page/c2m2-guidelines/#user-content-metadata)
 3. [Common Fund Data Asset Manifest](https://nih-cfde.org/engagement_page/c2m2-guidelines/#user-content-common-fund-data-asset-manifest)
 4. [Staff Expectations](https://nih-cfde.org/engagement_page/c2m2-guidelines/#user-content-staff-expectations)
-5. [Staff Expertise](https://nih-cfde.org/engagement_page/c2m2-guidelines/#user-content-staff-expertise)
-
----
+5. [Staff Expertise](https://nih-cfde.org/engagement_page/c2m2-guidelines/#user-content-staff-expertise) -->

--- a/content/recipes/Compliance/fairshake-rubric.md
+++ b/content/recipes/Compliance/fairshake-rubric.md
@@ -18,7 +18,7 @@ All projects that are part of the Common Fund Data Ecosystem (CFDE) are evaluate
 
 The FAIRshake insignia (pictured above) is a visual representation of a score given to a digital object based on a scoring rubric composed of metrics. It offers users a quick graphical view of the evaluation of the FAIR principles for that object. The number of colored boxes (non-gray) corresponds to the number of metrics in the rubric, whereas the color of the box indicates how well a metric adheres to FAIR principles (blue means full adherence and red not). Users can hover over the boxes to observe the score for each metric. The image below is from the [FAIRshake documentation page](https://fairshake.cloud/documentation/).
 
-![FAIRshake Insignia](ubric-images/image_1.png)
+![FAIRshake Insignia](rubric-images/image_1.png)
 
 ## FAIR Principles and Metrics Resources
 

--- a/content/recipes/Discoverability/C2M2-L1-description.md
+++ b/content/recipes/Discoverability/C2M2-L1-description.md
@@ -216,8 +216,8 @@ A table linking a subject, a subject_role (a named organism-level constituent co
 This section provides a concise overview of the key objects and concepts covered by the C2M2 model and should be viewed as an initial contact point for anyone interested in mapping data into the C2M2 model, thereby getting ready for a full ETL process.
 
 > ####  What to read next?
-> * [CFDE namespaces](../06/cfde-namespaces.html)
-> * [CFDE selected terminologies?](../14/cfde-terminologies.html)
+> * [CFDE namespaces](../06/cfde-namespaces.md)
+> * [CFDE selected terminologies?](../14/cfde-terminologies.md)
 
 
 

--- a/content/recipes/Discoverability/cfde-namespaces.md
+++ b/content/recipes/Discoverability/cfde-namespaces.md
@@ -166,6 +166,6 @@ namespce and the local names of the resources.
 This section provides a concise overview of the mechanism to declaring a `namespace` associated with a DCC in the context of the CFDE project. It is an important `harmonization` process, which aims to avoid collisions between identifiers, while enhancing `interoperability` and `findability`. It also represents a key process in mapping data into the C2M2 model, thereby getting ready for a full ETL process from a DCC to the CFDE model and future indexing in the CDFE Deriva system.
 
 > ####  What to read next?
-> * [CFDE selected terminologies](../Semantics/cfde-terminologies.html)
+> * [CFDE selected terminologies](../Semantics/cfde-terminologies.md)
 
 

--- a/content/recipes/Discoverability/index.md
+++ b/content/recipes/Discoverability/index.md
@@ -4,8 +4,8 @@ This section covers the F of the FAIR principles and thus describes the NIH CFDE
 
 It includes:
 
-- [the C2M2 model specifications](https://github.com/nih-cfde/specifications-and-documentation/tree/master/draft-C2M2_specification_with_Levels)
+- the C2M2 model specifications
 
-- [the CFDE namespace conventions](./cfde-namespaces.html) 
+- [the CFDE namespace conventions](./cfde-namespaces.md) 
 
-- [an ETL example to an early version of the C2M2 model in the DATS form.](./seo.html)
+- [an ETL example to an early version of the C2M2 model in the DATS form.](./seo.md)

--- a/content/recipes/Discoverability/kf.md
+++ b/content/recipes/Discoverability/kf.md
@@ -218,6 +218,6 @@ It will produce these four green tables for Level 1: `file_format.tsv`,`data_typ
 * Other examples of transformation are available or will be made available as guidance.
 
 > ####  What to read next?
-> * [CFDE C2M2 model](./c2m2.html)
-> * [ETL to CFDE C2M2 model](./seo.html)
+> * [CFDE C2M2 model](./c2m2.md)
+> * [ETL to CFDE C2M2 model](./seo.md)
 

--- a/content/recipes/Identification/identifiers.md
+++ b/content/recipes/Identification/identifiers.md
@@ -68,12 +68,12 @@ But `interoperability` goes far beyond reliable identification of these entities
 
 For all these entities, the **NIH CFDE** has identified a set of semantics artefacts/ontologies, the classes of which are all identified by PIDs and are used to annotated the datasets which will be represented in the [C2M2 model](https://www.nih-cfde.org/product/cfde-c2m2/) and made available through the [Deriva system](TODO:ADD_URL).
 
-* This specific [NIH-CFDE recipe](../14/cfde-terminologies.html) details which ontologies have been selected and how their use will be rolled out as the program progresses.
+* This specific [NIH-CFDE recipe](../14/cfde-terminologies.md) details which ontologies have been selected and how their use will be rolled out as the program progresses.
 
 It is important to notice that for such resources, a central authority is responsible for issueing (minting) those identifiers as well as providing the landing pages for the different content types associated with these kind of PIDs.
 This works well to address the semantic markup needs that arise in the data curation, data extraction transform load (ETL) processes. However, there is a need to be able to create resolvable identifiers on demands, for instance to uniquely identify data files. In order to discussion this specific use case, a specific document is available and details the use of [minids](https://fair-research.org/)
 
-* Refer to the specific recipe on [MINIDS](./2/minids.html) to learn how to mint such resolvable identifiers for your resources.
+* Refer to the specific recipe on [MINIDS](./2/minids.md) to learn how to mint such resolvable identifiers for your resources.
 
 
 

--- a/content/recipes/Semantics/cfde-terminologies.md
+++ b/content/recipes/Semantics/cfde-terminologies.md
@@ -71,7 +71,7 @@ ___
 * On the other hand, the harmonization tasks for domains such as `sample type`, `assay type` can be more involved, not to mention the case of `phenotypic descriptions` or `disease`, even though `level 0 and level 1 compliance` do not expect such a degree of integration.
 
 > ####  What to read next?
-> * [CFDE C2M2 model](../12/c2m2.html)
-> * [ETL to CFDE C2M2 model](../07/seo.html)
+> * [CFDE C2M2 model](../12/c2m2.md)
+> * [ETL to CFDE C2M2 model](../07/seo.md)
 
 

--- a/content/recipes/Semantics/onto-services.md
+++ b/content/recipes/Semantics/onto-services.md
@@ -97,7 +97,7 @@ Semantic artefacts (Lexicons, Controlled Terminologies, Ontologies) can be acces
 For specialized domains, it may be beneficial to access the specialized servers (e.g. Athena), as they, to some extent, limit to search space to only those resources relevant to the fields.
 This is in contrast to more general purpose, domain agnostic vocabulary services.
 > ####  What to read next?
-> * [CFDE selected terminologies?](../14/cfde-terminologies.html)
+> * [CFDE selected terminologies?](../14/cfde-terminologies.md)
 
 
 

--- a/content/recipes/Semantics/ontologies.md
+++ b/content/recipes/Semantics/ontologies.md
@@ -131,8 +131,8 @@ Choosing ontology and semantic resources is a complex issue, which requires care
 Clearly declaring the semantic resources used to annotate a dataset also influence `findability` and `reusability` and it is good practice to do so.
 
 > ####  What to read next?
-> * [Ontology services](./onto-services.html)
-> * [CFDE selected terminologies](./cfde-terminologies.html)
+> * [Ontology services](./onto-services.md)
+> * [CFDE selected terminologies](./cfde-terminologies.md)
 
 ___
 

--- a/content/recipes/recipes-overview.md
+++ b/content/recipes/recipes-overview.md
@@ -17,4 +17,4 @@ Click the following to see sections of the cookbook regarding:
 
 * [Semantics](./Semantics/semantics.md)
 
-* [Governance](./Governance/intro.md)
+* [Governance](./Governance/index.md)


### PR DESCRIPTION
Some leftover file extension changes from html to md. Fix link to governance section index.md.